### PR TITLE
Adding port 8126 to enable admin port usage

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -11,6 +11,7 @@ platforms:
     network:
       - ["forwarded_port", {guest: 80, host: 8080}]
       - ["forwarded_port", {guest: 8125, host: 8125}]
+      - ["forwarded_port", {guest: 8126, host: 8126}]
 
 suites:
   - name: linux

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -7,5 +7,5 @@ GRAPH
   compat_resource (12.5.12)
   docker (2.2.2)
     compat_resource (>= 0.0.0)
-  grafana-graphite-server (2.2.0)
+  grafana-graphite-server (2.3.1)
     docker (>= 0.0.0)

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'tech-team@7digital.com'
 license 'MIT'
 description 'Installs Grafana & Graphite'
 long_description 'Runs them via Docker'
-version '2.3.0'
+version '2.3.1'
 
 supports 'debian'
 

--- a/recipes/graphite.rb
+++ b/recipes/graphite.rb
@@ -35,6 +35,7 @@ docker_container 'graphite-statsd' do
   tag cookbook_version
   port [
     '8125:8125/udp',
+    '8126:8126/udp',
     '8080:80'
   ]
   binds [

--- a/test/integration/linux/serverspec/grafana_spec.rb
+++ b/test/integration/linux/serverspec/grafana_spec.rb
@@ -1,7 +1,7 @@
 require 'serverspec'
 set :backend, :exec
 
-cookbook_version = '2.2.0'
+cookbook_version = '2.3.1'
 
 describe 'grafana' do
   describe docker_image("7d-grafana:#{cookbook_version}") do

--- a/test/integration/linux/serverspec/graphite_spec.rb
+++ b/test/integration/linux/serverspec/graphite_spec.rb
@@ -2,7 +2,7 @@ require 'serverspec'
 require 'securerandom'
 set :backend, :exec
 
-cookbook_version = '2.2.0'
+cookbook_version = '2.3.1'
 
 describe 'graphite' do
   describe docker_image("7d-graphite-statsd:#{cookbook_version}") do
@@ -12,6 +12,8 @@ describe 'graphite' do
   describe docker_container('graphite-statsd') do
     it { should be_running }
     its(['HostConfig.PortBindings']) { should include '8125/udp' }
+    its(['HostConfig.PortBindings']) { should include '8126/udp' }
+    its(['HostConfig.PortBindings.8126/udp.[0].HostPort']) { should eq '8126' }
     its(['HostConfig.PortBindings.8125/udp.[0].HostPort']) { should eq '8125' }
     it { should have_volume('/opt/graphite/storage/whisper', '/var/whisper') }
     it { should have_volume('/var/log/graphite', '/var/log/graphite') }


### PR DESCRIPTION
To enable statsd cluster mode, we need to have access to the admin port for healthchecks